### PR TITLE
feat: copy default OCR model only if dir does not exist

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -11,10 +11,11 @@ def configure_ocr_model():
         print("请完整克隆本仓库，不要漏掉 \"--recursive\"，也不要下载 zip 包！")
         exit(1)
 
-    if not (assets_dir / "resource" / "base" / "model" / "ocr").exists():   # copy default OCR model only if dir does not exist
+    ocr_dir = assets_dir / "resource" / "base" / "model" / "ocr"
+    if not ocr_dir.exists():   # copy default OCR model only if dir does not exist
         shutil.copytree(
             assets_dir / "MaaCommonAssets" / "OCR" / "ppocr_v4" / "zh_cn",
-            assets_dir / "resource" / "base" / "model" / "ocr",
+            ocr_dir,
             dirs_exist_ok=True,
         )
     else:

--- a/configure.py
+++ b/configure.py
@@ -11,11 +11,14 @@ def configure_ocr_model():
         print("请完整克隆本仓库，不要漏掉 \"--recursive\"，也不要下载 zip 包！")
         exit(1)
 
-    shutil.copytree(
-        assets_dir / "MaaCommonAssets" / "OCR" / "ppocr_v4" / "zh_cn",
-        assets_dir / "resource" / "base" / "model" / "ocr",
-        dirs_exist_ok=True,
-    )
+    if not (assets_dir / "resource" / "base" / "model" / "ocr").exists():   # copy default OCR model only if dir does not exist
+        shutil.copytree(
+            assets_dir / "MaaCommonAssets" / "OCR" / "ppocr_v4" / "zh_cn",
+            assets_dir / "resource" / "base" / "model" / "ocr",
+            dirs_exist_ok=True,
+        )
+    else:
+        print("Found existing OCR directory, skipping default OCR model import.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
proposing a fix for #4 ,
it will now copy the default OCR assets only if there is not an existing ocr directory.