### PR TITLE
feat(tools): 更新默认OCR模型为ppocr_v6/small

### DIFF
--- a/tools/configure.py
+++ b/tools/configure.py
@@ -14,7 +14,7 @@ def configure_ocr_model():
     ocr_dir = assets_dir / "resource" / "model" / "ocr"
     if not ocr_dir.exists():   # copy default OCR model only if dir does not exist
         shutil.copytree(
-            assets_dir / "MaaCommonAssets" / "OCR" / "ppocr_v5" / "zh_cn",
+            assets_dir / "MaaCommonAssets" / "OCR" / "ppocr_v6" / "small",
             ocr_dir,
             dirs_exist_ok=True,
         )


### PR DESCRIPTION
# Pull Request

提交前请阅读 [PR 规范](../docs/zh_cn/develop/pull_request_guidelines.md)。

## 关联 Issue
https://github.com/MaaXYZ/MaaFramework/issues/1370

## 变更摘要

更新默认OCR模型为ppocr_v6/small

## 验证

<!-- 请写清楚执行了什么验证、结果如何。不要只写“已测试”。 -->

- [x] 我已阅读并遵守 [PR 规范](../docs/zh_cn/develop/pull_request_guidelines.md)

## Summary by Sourcery

新功能：
- 在配置脚本中，将默认的 OCR 模型路径从 `ppocr_v5/zh_cn` 切换为 `ppocr_v6/small`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Switch the default OCR model path from ppocr_v5/zh_cn to ppocr_v6/small in the configuration script.

</details>